### PR TITLE
feat: timeline-style our story section on /about

### DIFF
--- a/e2e/announcements.spec.ts
+++ b/e2e/announcements.spec.ts
@@ -10,12 +10,11 @@ test.describe('Announcements Page', () => {
   })
 
   test('shows Announcements heading', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: 'Announcements' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: /Stay in the loop/i })).toBeVisible()
   })
 
   test('shows pricing update announcement', async ({ page }) => {
     await expect(page.getByText('Pricing Update - Effective November 1, 2025')).toBeVisible()
-    await expect(page.getByText('November 1, 2025').first()).toBeVisible()
   })
 
   test('announcement is clickable', async ({ page }) => {

--- a/e2e/community.spec.ts
+++ b/e2e/community.spec.ts
@@ -10,7 +10,7 @@ test.describe('Community Page', () => {
   })
 
   test('shows Community Engagement heading', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: /Community Engagement/i })).toBeVisible()
+    await expect(page.getByRole('heading', { name: /Building together with our community/i })).toBeVisible()
   })
 
   test('shows Featured Events section', async ({ page }) => {

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -16,8 +16,8 @@ test.describe('Home Page', () => {
   })
 
   test('shows Explore Solutions and View Community buttons', async ({ page }) => {
-    await expect(page.getByRole('link', { name: 'Explore Solutions' })).toBeVisible()
-    await expect(page.getByRole('link', { name: 'View Community' })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Explore Solutions', exact: true })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'View Community', exact: true })).toBeVisible()
   })
 
   test('shows services section', async ({ page }) => {
@@ -28,15 +28,15 @@ test.describe('Home Page', () => {
   })
 
   test('shows coworking spaces bento grid', async ({ page }) => {
-    await expect(page.getByText('Entrance Area')).toBeVisible()
-    await expect(page.getByText('Inner Area')).toBeVisible()
-    await expect(page.getByText('Call Booths')).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Entrance Area', exact: true })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Inner Area', exact: true })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Call Booths', exact: true })).toBeVisible()
   })
 
   test('shows future services cards', async ({ page }) => {
-    await expect(page.getByText('Business Registration')).toBeVisible()
-    await expect(page.getByText('Event Management')).toBeVisible()
-    await expect(page.getByText('Custom Software')).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Business Registration', exact: true })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Event Management', exact: true })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Custom Software', exact: true })).toBeVisible()
   })
 
   test('shows connect section with social links', async ({ page }) => {
@@ -48,7 +48,7 @@ test.describe('Home Page', () => {
   })
 
   test('shows location status', async ({ page }) => {
-    await expect(page.getByText('Panganiban Drive — Open')).toBeVisible()
+    await expect(page.locator('#hero').getByText('Panganiban Drive — Open')).toBeVisible()
   })
 
   test('shows navigation header', async ({ page }) => {

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -2,15 +2,14 @@ import { test, expect } from './fixtures'
 
 test.describe('Navigation', () => {
   test('all nav links work from home', async ({ page, viewport }) => {
-    const isMobile = (viewport?.width ?? 1280) < 768
+    const isMobile = (viewport?.width ?? 1280) < 1024
 
     const clickNavLink = async (name: string) => {
       if (isMobile) {
-        await page.getByRole('button', { name: 'Toggle menu' }).click()
-        // Mobile nav links are inside a fixed nav overlay
+        // Tablet/mobile use the fixed bottom nav; desktop uses the header nav
         await page.locator('nav.fixed').getByRole('link', { name, exact: true }).click()
       } else {
-        await page.getByRole('link', { name }).first().click()
+        await page.getByRole('link', { name, exact: true }).first().click()
       }
     }
 
@@ -35,15 +34,12 @@ test.describe('Navigation', () => {
     await expect(page).toHaveURL('/')
   })
 
-  test('mobile menu opens and closes', async ({ page, viewport }) => {
-    if ((viewport?.width ?? 1280) >= 768) {
+  test('mobile bottom nav is visible', async ({ page, viewport }) => {
+    if ((viewport?.width ?? 1280) >= 1024) {
       test.skip()
     }
     await page.goto('/')
-    const menuButton = page.getByRole('button', { name: 'Toggle menu' })
-    await menuButton.click()
     await expect(page.locator('nav.fixed')).toBeVisible()
-    await page.keyboard.press('Escape')
   })
 })
 

--- a/src/routes/about.tsx
+++ b/src/routes/about.tsx
@@ -83,55 +83,81 @@ const AboutPage: Component = () => {
               <h2 class="text-3xl md:text-4xl font-bold text-white">From college projects to a corporation.</h2>
             </div>
 
-            <div class="space-y-6">
-              {/* Timeline items */}
-              <div class="relative clip-corner-both bg-zinc-900/40 border border-zinc-800/30 overflow-hidden group hover:border-amber-500/20 transition-all">
-                <div class="grid grid-cols-1 md:grid-cols-[160px_1fr] gap-0">
-                  <div class="flex items-center justify-center p-4 md:p-8 bg-zinc-900/60 border-b md:border-b-0 md:border-r border-zinc-800/30">
-                    <div class="flex items-center gap-2">
-                      <Users size={16} class="text-amber-400" />
-                      <span class="text-amber-400 text-xs font-bold tracking-widest uppercase">Origins</span>
+            <div class="relative md:pl-[140px]">
+              {/* Vertical rail line connecting the dots (desktop only) */}
+              <div class="hidden md:block absolute left-[60px] top-8 bottom-8 w-px bg-zinc-800/60" />
+
+              <div class="space-y-6">
+                {/* Timeline items */}
+                <div class="relative group">
+                  <div class="hidden md:flex flex-col items-center absolute -left-[140px] top-8 w-[120px]">
+                    <div class="w-[18px] h-[18px] rounded-full bg-amber-500 border-4 border-zinc-950 z-10 group-hover:scale-125 transition-transform" />
+                    <div class="mt-3 flex flex-col items-center gap-1">
+                      <Users size={14} class="text-amber-400" />
+                      <span class="text-amber-400 text-xs font-black tracking-widest uppercase">Origins</span>
                     </div>
                   </div>
-                  <div class="p-5 md:p-10">
-                    <h3 class="text-lg md:text-xl font-bold text-white mb-3">Met in college, built for fun</h3>
-                    <p class="text-zinc-400 leading-relaxed">
-                      The founding members of KahitSan met in college. We started working on fun projects together — building things, breaking things, and learning as we went. That shared energy eventually became the foundation for something bigger.
-                    </p>
+                  <div class="relative clip-corner-both bg-zinc-900/40 border border-zinc-800/30 overflow-hidden group-hover:border-amber-500/20 transition-all">
+                    <div class="flex md:hidden items-center justify-center p-4 bg-zinc-900/60 border-b border-zinc-800/30">
+                      <div class="flex items-center gap-2">
+                        <Users size={16} class="text-amber-400" />
+                        <span class="text-amber-400 text-xs font-bold tracking-widest uppercase">Origins</span>
+                      </div>
+                    </div>
+                    <div class="p-5 md:p-10">
+                      <h3 class="text-lg md:text-xl font-bold text-white mb-3">Met in college, built for fun</h3>
+                      <p class="text-zinc-400 leading-relaxed">
+                        The founding members of KahitSan met in college. We started working on fun projects together — building things, breaking things, and learning as we went. That shared energy eventually became the foundation for something bigger.
+                      </p>
+                    </div>
                   </div>
                 </div>
-              </div>
 
-              <div class="relative clip-corner-both bg-zinc-900/40 border border-zinc-800/30 overflow-hidden group hover:border-amber-500/20 transition-all">
-                <div class="grid grid-cols-1 md:grid-cols-[160px_1fr] gap-0">
-                  <div class="flex items-center justify-center p-4 md:p-8 bg-zinc-900/60 border-b md:border-b-0 md:border-r border-zinc-800/30">
-                    <div class="flex items-center gap-2">
-                      <MapPin size={16} class="text-amber-400" />
-                      <span class="text-amber-400 text-xs font-bold tracking-widest uppercase">2025</span>
+                <div class="relative group">
+                  <div class="hidden md:flex flex-col items-center absolute -left-[140px] top-8 w-[120px]">
+                    <div class="w-[18px] h-[18px] rounded-full bg-amber-500 border-4 border-zinc-950 z-10 group-hover:scale-125 transition-transform" />
+                    <div class="mt-3 flex flex-col items-center gap-1">
+                      <MapPin size={14} class="text-amber-400" />
+                      <span class="text-amber-400 text-xs font-black tracking-widest uppercase">2025</span>
                     </div>
                   </div>
-                  <div class="p-5 md:p-10">
-                    <h3 class="text-lg md:text-xl font-bold text-white mb-3">Testing the market in Naga City</h3>
-                    <p class="text-zinc-400 leading-relaxed">
-                      Before any formal business structure, we were already on the ground — testing the coworking space concept in Naga City, Philippines. We wanted to know if there was real demand for an affordable, reliable workspace. There was.
-                    </p>
+                  <div class="relative clip-corner-both bg-zinc-900/40 border border-zinc-800/30 overflow-hidden group-hover:border-amber-500/20 transition-all">
+                    <div class="flex md:hidden items-center justify-center p-4 bg-zinc-900/60 border-b border-zinc-800/30">
+                      <div class="flex items-center gap-2">
+                        <MapPin size={16} class="text-amber-400" />
+                        <span class="text-amber-400 text-xs font-bold tracking-widest uppercase">2025</span>
+                      </div>
+                    </div>
+                    <div class="p-5 md:p-10">
+                      <h3 class="text-lg md:text-xl font-bold text-white mb-3">Testing the market in Naga City</h3>
+                      <p class="text-zinc-400 leading-relaxed">
+                        Before any formal business structure, we were already on the ground — testing the coworking space concept in Naga City, Philippines. We wanted to know if there was real demand for an affordable, reliable workspace. There was.
+                      </p>
+                    </div>
                   </div>
                 </div>
-              </div>
 
-              <div class="relative clip-corner-both bg-zinc-900/40 border border-zinc-800/30 overflow-hidden group hover:border-amber-500/20 transition-all">
-                <div class="grid grid-cols-1 md:grid-cols-[160px_1fr] gap-0">
-                  <div class="flex items-center justify-center p-4 md:p-8 bg-zinc-900/60 border-b md:border-b-0 md:border-r border-zinc-800/30">
-                    <div class="flex items-center gap-2">
-                      <Rocket size={16} class="text-amber-400" />
-                      <span class="text-amber-400 text-xs font-bold tracking-widest uppercase">2026</span>
+                <div class="relative group">
+                  <div class="hidden md:flex flex-col items-center absolute -left-[140px] top-8 w-[120px]">
+                    <div class="w-[18px] h-[18px] rounded-full bg-amber-500 border-4 border-zinc-950 z-10 group-hover:scale-125 transition-transform" />
+                    <div class="mt-3 flex flex-col items-center gap-1">
+                      <Rocket size={14} class="text-amber-400" />
+                      <span class="text-amber-400 text-xs font-black tracking-widest uppercase">2026</span>
                     </div>
                   </div>
-                  <div class="p-5 md:p-10">
-                    <h3 class="text-lg md:text-xl font-bold text-white mb-3">KahitSan Corporation</h3>
-                    <p class="text-zinc-400 leading-relaxed">
-                      In 2026, we formalized the team — registering KahitSan as a corporation in the Philippines and establishing the directors who will continue to manage the company. We're fully bootstrapped, funding everything from our own pockets as we explore different target markets and figure out how to scale on our own terms.
-                    </p>
+                  <div class="relative clip-corner-both bg-zinc-900/40 border border-zinc-800/30 overflow-hidden group-hover:border-amber-500/20 transition-all">
+                    <div class="flex md:hidden items-center justify-center p-4 bg-zinc-900/60 border-b border-zinc-800/30">
+                      <div class="flex items-center gap-2">
+                        <Rocket size={16} class="text-amber-400" />
+                        <span class="text-amber-400 text-xs font-bold tracking-widest uppercase">2026</span>
+                      </div>
+                    </div>
+                    <div class="p-5 md:p-10">
+                      <h3 class="text-lg md:text-xl font-bold text-white mb-3">KahitSan Corporation</h3>
+                      <p class="text-zinc-400 leading-relaxed">
+                        In 2026, we formalized the team — registering KahitSan as a corporation in the Philippines and establishing the directors who will continue to manage the company. We're fully bootstrapped, funding everything from our own pockets as we explore different target markets and figure out how to scale on our own terms.
+                      </p>
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Redesigns the Our Story timeline on /about so the year markers (Origins, 2025, 2026) sit outside the cards on a vertical rail, with a connecting line running through amber dots. Mobile keeps the in-card label bar because the external rail does not make sense in a narrow column.

While verifying locally I hit 15 pre-existing e2e failures on main caused by drift between older specs and the newer homepage bento redesign plus the switch from the hamburger menu to a fixed bottom nav, so I fixed those in the same branch. Home selectors now use the heading role with exact matching to avoid strict-mode ambiguity, the announcement and community heading checks match the current copy, and the navigation spec targets the bottom nav instead of the removed Toggle menu button. No e2e coverage was added for /about itself since the change is purely visual rearrangement.