### PR TITLE
fix: HUD button styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "kahitsan-web",
       "version": "0.1.0",
       "dependencies": {
-        "@kahitsan/ksui": "^0.7.1",
+        "@kahitsan/ksui": "^0.32.0",
         "@solidjs/meta": "^0.29.4",
         "@solidjs/router": "^0.16.1",
         "@solidjs/start": "^1.3.2",
@@ -1112,15 +1112,21 @@
       }
     },
     "node_modules/@kahitsan/ksui": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@kahitsan/ksui/-/ksui-0.7.1.tgz",
-      "integrity": "sha512-iR0jyiVKXUJ6OvMZSnNu++Qqy+G9GRvQHh9SIHJVTLazKi3evuem0jERYc6jaY06+0WnV7YEEvz4O9mrfFLoKA==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@kahitsan/ksui/-/ksui-0.32.0.tgz",
+      "integrity": "sha512-Htf6RESu7ETE7HBYXAtrle9H/jMKAUNXf9QsBTcYNjsrq/isr9Ft8PMSy43iRION5MowsS/hO6b1k0y96eO4Gw==",
       "license": "MIT",
       "dependencies": {
         "lucide-solid": "^1.7.0"
       },
       "peerDependencies": {
-        "solid-js": "^1.9.0"
+        "solid-js": "^1.9.0",
+        "tailwindcss": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "tailwindcss": {
+          "optional": true
+        }
       }
     },
     "node_modules/@kahitsan/ksui/node_modules/lucide-solid": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:ui": "playwright test --ui"
   },
   "dependencies": {
-    "@kahitsan/ksui": "^0.7.1",
+    "@kahitsan/ksui": "^0.32.0",
     "@solidjs/meta": "^0.29.4",
     "@solidjs/router": "^0.16.1",
     "@solidjs/start": "^1.3.2",

--- a/src/assets/css/app.css
+++ b/src/assets/css/app.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@source "../../../node_modules/@kahitsan/ksui/src";
 
 @custom-variant dark (&:where(.dark, .dark *));
 

--- a/src/components/ui/NotFound/NotFound.tsx
+++ b/src/components/ui/NotFound/NotFound.tsx
@@ -53,7 +53,7 @@ const NotFound: Component<NotFoundProps> = (props) => {
           {local.message || "The page you're looking for doesn't exist or has been moved."}
         </p>
         {!local.hideButton && (
-          <Button intent="primary" size="lg" onClick={handleButtonClick}>
+          <Button intent="primary" onClick={handleButtonClick}>
             {local.buttonText || 'Go Back Home'}
           </Button>
         )}

--- a/src/routes/about.tsx
+++ b/src/routes/about.tsx
@@ -225,7 +225,6 @@ const AboutPage: Component = () => {
                   rel="noopener noreferrer"
                   intent="primary"
                   variant="clip1"
-                  size="lg"
                   effect="scan-line"
                   icon={() => <Facebook size={18} />}
                   iconPosition="left"

--- a/src/routes/community.tsx
+++ b/src/routes/community.tsx
@@ -216,7 +216,6 @@ const CommunityPage: Component = () => {
                   rel="noopener noreferrer"
                   intent="primary"
                   variant="clip1"
-                  size="lg"
                   effect="scan-line"
                   icon={() => <Facebook size={18} />}
                   iconPosition="left"

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -108,10 +108,10 @@ const HomePage: Component = () => {
                 KahitSan man pinanggalingan mo.
               </p>
               <div class="flex flex-wrap gap-4">
-                <Button as={A} href="/solutions" intent="primary" size="lg" effect="scan-line">
+                <Button as={A} href="/solutions" intent="primary" effect="scan-line">
                   Explore Solutions
                 </Button>
-                <Button as={A} href="/community" intent="secondary" size="lg">
+                <Button as={A} href="/community" intent="secondary">
                   View Community
                 </Button>
               </div>


### PR DESCRIPTION
The hero/CTA buttons had no background, border, or HUD clip-corner — just plain text. Turns out Tailwind v4's content scanner skips node_modules, and the class names driving these buttons (bg-amber-600/20, border-amber-600/60, etc.) only exist inside @kahitsan/ksui's source in node_modules — so they were never compiled into the CSS at all. Added an explicit @source for the ksui package to fix that.

Also bumped ksui from 0.7.1 to 0.32.0 (24 versions stale) — the `size` prop on Button was added in 0.31.0, so `size="lg"` calls were silently no-ops as dead DOM attributes. Removed them since ksui's Button now only supports "sm"/"md" and "md" (default) matches the existing look.

# Testing Method
- via Playwright MCP, walked the homepage in light and dark mode