### PR TITLE
fix: no-cache header for root path

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -18,6 +18,13 @@
 /index.html
   Cache-Control: public, max-age=0, must-revalidate
 
+# Bare "/" is a distinct request path from "/index.html" in Cloudflare Pages
+# header matching (it matches on literal path, not resolved file) — without
+# this rule it falls through to the /* immutable rule above and caches the
+# HTML shell (with stale hashed asset references) for a year.
+/
+  Cache-Control: public, max-age=0, must-revalidate
+
 # Service worker (if you add one later)
 /sw.js
   Cache-Control: public, max-age=0, must-revalidate


### PR DESCRIPTION
## Summary
- The `_headers` cache rules for `/*.html` and `/index.html` don't match the bare `/` request path (Cloudflare Pages matches headers on the literal request path, not the resolved file), so `/` fell through to the `/*` rule and got cached `immutable` for a year at the edge and in browsers.
- That meant every new deploy's `index.html` (with fresh hashed asset references) stayed masked behind a stale cached homepage referencing old asset hashes — surfacing as `Failed to load module script ... MIME type text/html` console errors once the old hashed files were pruned from a later deploy.
- Adds an explicit `/` rule with `Cache-Control: public, max-age=0, must-revalidate`, matching the existing `/index.html` and `/*.html` rules.

## Test plan
- [x] Verified via Playwright that `GET https://www.kahitsan.com/` currently returns `Cache-Control: public, max-age=31536000, immutable` (reproduces the bug)
- [ ] After merge + deploy, re-check response headers for `/` show `max-age=0, must-revalidate`
- [ ] Re-check homepage console for the module MIME errors on the next deploy after this lands