### PR TITLE
fix: prevent edge cache-poisoning at build-asset paths (CSS broken on prod)

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -7,7 +7,17 @@
   Referrer-Policy: strict-origin-when-cross-origin
   X-XSS-Protection: 1; mode=block
 
-  # Cache Control for static assets
+  # No-cache floor for EVERY path. The _redirects /* → /404/index.html fallback
+  # can serve the HTML 404 shell at a missing asset URL during a deploy-window
+  # gap; if that HTML were tagged immutable it pins the wrong body for a year
+  # (the cache-poisoning incident — HTML served at a .css path). Real hashed
+  # assets override this below; everything else revalidates so a misroute heals.
+  Cache-Control: public, max-age=0, must-revalidate
+
+# Content-hashed build assets are the only paths safe to cache immutably —
+# their filename changes on every build, so a stale entry can never shadow a
+# new one. Must be stated explicitly because /* above is no-cache.
+/_build/assets/*
   Cache-Control: public, max-age=31536000, immutable
 
 # HTML files should not be cached aggressively
@@ -19,9 +29,7 @@
   Cache-Control: public, max-age=0, must-revalidate
 
 # Bare "/" is a distinct request path from "/index.html" in Cloudflare Pages
-# header matching (it matches on literal path, not resolved file) — without
-# this rule it falls through to the /* immutable rule above and caches the
-# HTML shell (with stale hashed asset references) for a year.
+# header matching (it matches on literal path, not resolved file).
 /
   Cache-Control: public, max-age=0, must-revalidate
 

--- a/public/_redirects
+++ b/public/_redirects
@@ -3,5 +3,12 @@
 # Redirect non-www to www
 https://kahitsan.com/*    https://www.kahitsan.com/:splat    301
 
+# Build assets that don't exist must fail, not fall through to the HTML shell.
+# During a deploy-window gap a missing /_build/assets/* request would otherwise
+# hit the /* fallback below, serve the 404 HTML body at the asset URL, and (under
+# an immutable cache rule) get pinned as cache-poisoned HTML at a .css/.js path.
+# 404 status is not edge-cached by Pages, so this heals on the next request.
+/_build/assets/*    /404/index.html   404
+
 # Fallback: serve 404 page for unknown routes
 /*    /404/index.html   404


### PR DESCRIPTION
kahitsan.com rendered with no CSS because Cloudflare's edge cache held a poisoned entry: the stylesheet URL returned the HTML 404 shell, not the real file. The origin is healthy — the same .css with a cache-buster returns the real stylesheet, so this is cache poisoning, not a code bug.

The cause was _redirects serving the HTML shell at unmatched paths (a build-asset URL missing during a deploy gap) while _headers tagged everything immutable, pinning that body for a year. This PR scopes immutable caching to hashed assets under /_build/assets/* and makes _redirects 404 a missing asset instead of serving the shell.

The site stays broken until the cache is purged: Cloudflare dashboard → kahitsan.com → Caching → Purge Everything. Merging this PR also invalidates it via new asset hashes.

# Testing Method
- npm run build succeeds and the prod .css returns real with a cache-buster